### PR TITLE
Add optionals/nullables for function arguments definition

### DIFF
--- a/src/autolua.zig
+++ b/src/autolua.zig
@@ -172,6 +172,11 @@ pub fn check(L: ?*lua.lua_State, idx: c_int, comptime T: type) T {
             // lua.lua_pop(L, 1);
             // const ptr = lua.lua_touserdata(L, idx);
         },
+        .Optional => |N| {
+            if (lua.lua_type(L, idx)<lua.LUA_TBOOLEAN)
+                return null;
+            return check(L, idx, N.child);
+        },
         else => @compileError("unable to coerce to type: " ++ @typeName(T)),
     }
 }

--- a/src/autolua.zig
+++ b/src/autolua.zig
@@ -173,7 +173,7 @@ pub fn check(L: ?*lua.lua_State, idx: c_int, comptime T: type) T {
             // const ptr = lua.lua_touserdata(L, idx);
         },
         .Optional => |N| {
-            if (lua.lua_type(L, idx)<lua.LUA_TBOOLEAN){
+            if (lua.lua_type(L, idx)<lua.LUA_TBOOLEAN) {
                 return null;
             } 
             return check(L, idx, N.child);

--- a/src/autolua.zig
+++ b/src/autolua.zig
@@ -173,7 +173,7 @@ pub fn check(L: ?*lua.lua_State, idx: c_int, comptime T: type) T {
             // const ptr = lua.lua_touserdata(L, idx);
         },
         .Optional => |N| {
-            if (lua.lua_type(L, idx) < lua.LUA_TBOOLEAN) {
+            if (lua.lua_isnoneornil(L, idx)) {
                 return null;
             } 
             return check(L, idx, N.child);

--- a/src/autolua.zig
+++ b/src/autolua.zig
@@ -173,8 +173,9 @@ pub fn check(L: ?*lua.lua_State, idx: c_int, comptime T: type) T {
             // const ptr = lua.lua_touserdata(L, idx);
         },
         .Optional => |N| {
-            if (lua.lua_type(L, idx)<lua.LUA_TBOOLEAN)
+            if (lua.lua_type(L, idx)<lua.LUA_TBOOLEAN){
                 return null;
+            } 
             return check(L, idx, N.child);
         },
         else => @compileError("unable to coerce to type: " ++ @typeName(T)),

--- a/src/autolua.zig
+++ b/src/autolua.zig
@@ -173,7 +173,7 @@ pub fn check(L: ?*lua.lua_State, idx: c_int, comptime T: type) T {
             // const ptr = lua.lua_touserdata(L, idx);
         },
         .Optional => |N| {
-            if (lua.lua_type(L, idx)<lua.LUA_TBOOLEAN) {
+            if (lua.lua_type(L, idx) < lua.LUA_TBOOLEAN) {
                 return null;
             } 
             return check(L, idx, N.child);


### PR DESCRIPTION
This will allow for optional arguments in functions, example:

main.zig:
```zig
autolua.pushlib(LuaState, struct {
     pub fn numberOrZero(num: ?u8) u8 {
          return num orelse 0;
     }
})
```

main.lua:
```lua
print(library.numberOrZero(24))
print(library.numberOrZero(nil))
print(library.numberOrZero())
```

results:
```
24
0
0
```

This is my first PR ever to any zig project and to anything related with the lua api in general, if i did something wrong please let me know :)