### PR TITLE
Add array & nullables support for push and a configuration struct

### DIFF
--- a/src/autolua.zig
+++ b/src/autolua.zig
@@ -36,6 +36,7 @@ pub fn push(L: ?*lua.lua_State, value: anytype) void {
     const T = @TypeOf(value);
     switch (@typeInfo(@TypeOf(value))) {
         .Void => lua.lua_pushnil(L),
+        .Null => lua.lua_pushnil(L),
         .Bool => lua.lua_pushboolean(L, @boolToInt(value)),
         .Int => |IntInfo| {
             assert(LuaIntTypeInfo.signedness == .signed);
@@ -83,6 +84,13 @@ pub fn push(L: ?*lua.lua_State, value: anytype) void {
                 push(L, x);
                 lua.lua_rawseti(L, -2, @intCast(c_int, i+1));
             }
+        },
+        .Optional => |N| {
+            if (value == null) {
+                lua.lua_pushnil(L);
+                return;
+            }
+            push(L, value.?);
         },
         else => @compileError("unable to coerce from type '" ++ @typeName(@TypeOf(value)) ++ "'"),
     }

--- a/src/autolua.zig
+++ b/src/autolua.zig
@@ -87,10 +87,9 @@ pub fn push(L: ?*lua.lua_State, value: anytype) void {
         },
         .Optional => |N| {
             if (value == null) {
-                lua.lua_pushnil(L);
-            } else {
-                push(L, value.?);
+                return push(L, null);
             }
+            push(L, value.?);
         },
         else => @compileError("unable to coerce from type '" ++ @typeName(@TypeOf(value)) ++ "'"),
     }

--- a/src/autolua.zig
+++ b/src/autolua.zig
@@ -88,9 +88,9 @@ pub fn push(L: ?*lua.lua_State, value: anytype) void {
         .Optional => |N| {
             if (value == null) {
                 lua.lua_pushnil(L);
-                return;
+            } else {
+                push(L, value.?);
             }
-            push(L, value.?);
         },
         else => @compileError("unable to coerce from type '" ++ @typeName(@TypeOf(value)) ++ "'"),
     }

--- a/src/autolua.zig
+++ b/src/autolua.zig
@@ -77,6 +77,13 @@ pub fn push(L: ?*lua.lua_State, value: anytype) void {
                 // TODO: fill in the metatable with info about the type?
             }
         },
+        .Array => |A| {
+            lua.lua_createtable(L, 0, A.len);
+            for (value) |x, i| {
+                push(L, x);
+                lua.lua_rawseti(L, -2, @intCast(c_int, i+1));
+            }
+        },
         else => @compileError("unable to coerce from type '" ++ @typeName(@TypeOf(value)) ++ "'"),
     }
 }


### PR DESCRIPTION
This will allow to:
- Return arrays as tables (as long as the type is compatible)
- Return null as nil or null userdata
- Return optional/nullable
- Configurate Autolua using a struct

main.zig:
```zig
pub fn superDopeCount() [10]u8 {
    var count: [10]u8 = undefined;
    for (count) | _, i | {
        count[i] = @intCast(u8, i+1);
    }
    return count;
}

pub fn trueOrNil(in: bool) ?bool {
    return if (in) true else null;
}

pub fn main() !void {
    autolua.options.NullType = .nil;
    ...
```

main.lua
```lua
for _, v in ipairs(lib.superDopeCount()) do
    print(v)
end

print(lib.trueOrNil(true))
print(lib.trueOrNil(false))
```

result:
```
1
2
3
4
5
6
7
8
9
10
true
nil
```
